### PR TITLE
DEP 4 branch dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/recipe-plugin": "^1",
-        "cwp/cwp-search": "1.6.x-dev",
-        "silverstripe/fulltextsearch": "3.9.x-dev",
+        "cwp/cwp-search": "1.x-dev",
+        "silverstripe/fulltextsearch": "3.x-dev",
         "symbiote/silverstripe-queuedjobs": "^4"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/531

This PR's a bit different from the other recipe pull-requests that it targets the next-minor branch, rather than the current-minor

Looks like what happened is this wasn't merged up correctly during the 4.10 CMS release, so this is fixing that.