### PR TITLE
FIX Ensure injectable version of queuedjobs is installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         "silverstripe/recipe-plugin": "^1",
         "cwp/cwp-search": "1.6.x-dev",
         "silverstripe/fulltextsearch": "3.9.x-dev",
-        "symbiote/silverstripe-queuedjobs": "^4"
+        "symbiote/silverstripe-queuedjobs": "^4.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3",
-        "cwp/cwp": "^2",
+        "cwp/cwp": "^2.9",
         "cwp/cwp-core": "^2",
         "cwp/starter-theme": "^2"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix prefer-lowest
https://github.com/silverstripe/recipe-solr-search/runs/7440645243?check_suite_focus=true
`ERROR [Emergency]: Uncaught Error: Call to undefined method Symbiote\QueuedJobs\Services\QueuedJobService::singleton()`
https://github.com/silverstripe/recipe-solr-search/runs/7440645243?check_suite_focus=true#step:10:859

^ required queuedjobs 4.9 rather than 4.1 due to the requirement for PHPUnit9 compatibility

https://github.com/silverstripe/recipe-solr-search/runs/7441484862?check_suite_focus=true#step:12:55
`Fatal error: Declaration of Symbiote\QueuedJobs\Tests\AbstractTest::setUp() must be compatible with SilverStripe\Dev\SapphireTest::setUp(): void in /home/runner/work/recipe-solr-search/recipe-solr-search/vendor/symbiote/silverstripe-queuedjobs/tests/AbstractTest.php on line 17`

Fix
`Incorrect DATETIME value: 'christmas 00:00:00'`
https://github.com/silverstripe/recipe-solr-search/runs/7440645405?check_suite_focus=true#step:12:88

Maybe fix
`1) SilverStripe\FullTextSearch\Tests\BatchedProcessorTest::testBatching
Failed asserting that 15 matches expected 9.`
https://github.com/silverstripe/recipe-solr-search/runs/7440645300?check_suite_focus=true#step:12:69